### PR TITLE
Add English output mode option and improve progress tracking

### DIFF
--- a/example.mp4.meta.json
+++ b/example.mp4.meta.json
@@ -1,0 +1,22 @@
+{
+  "system": {
+    "no_speech": {
+      "detected": true,
+      "whisper_model": "medium",
+      "created_utc": 1766800000.123,
+      "file_sig": { "size": 123456789, "mtime": 1766799000.0 }
+    }
+  },
+  "media": {
+    "duration_s": 1482.53,
+    "file_sig": { "size": 123456789, "mtime": 1766799000.0 }
+  },
+  "user": {
+    "tags": ["cozy", "anime"],
+    "notes": "Great dub"
+  },
+  "meta": {
+    "genres": ["Drama"],
+    "release_date": "2019-10-03"
+  }
+}

--- a/example.mp4.meta.json
+++ b/example.mp4.meta.json
@@ -7,7 +7,7 @@
       "file_sig": { "size": 123456789, "mtime": 1766799000.0 }
     }
   },
-  "media": {
+  "data": {
     "duration_s": 1482.53,
     "file_sig": { "size": 123456789, "mtime": 1766799000.0 }
   },

--- a/src/core.py
+++ b/src/core.py
@@ -102,9 +102,20 @@ def process_one_video(
 
     if detected_lang == "en":
         if english_output_mode == "non_english_only":
+            if existing_srt_mode == "overwrite":
+                final_srt_path.unlink(missing_ok=True)
+
             if status:
-                status("Skipped", f"English detected; not writing .en.srt (translate-only mode): {video_path.name}")
-            return Result(True, "skipped (english; translate-only mode)", video_path.name, time.perf_counter() - t0)
+                status(
+                    "Skipped",
+                    f"English detected; not writing .en.srt (translate-only mode): {video_path.name}"
+                )
+            return Result(
+                True,
+                "skipped (english; translate-only mode)",
+                video_path.name,
+                time.perf_counter() - t0,
+            )
 
         if status:
             status("Finalize", f"Writing English SRT: {video_path.name}")
@@ -166,7 +177,20 @@ def run_batch(
     completed = 0
 
     durations = []
-    for v in videos:
+    total_videos = len(videos)
+
+    for i, v in enumerate(videos, 1):
+        if should_cancel and should_cancel():
+            if status:
+                status("Cancelled", "Stopped while scanning media durations.")
+            return results
+
+        if status and i % 5 == 0:
+            status(
+                "Scanning",
+                f"Reading media info ({i}/{total_videos})…"
+            )
+
         dur = _media_duration_seconds(v)
         durations.append(dur)
 


### PR DESCRIPTION
Introduces an 'english_output_mode' setting to control whether English subtitles are generated for all videos or only for non-English videos. Updates the UI to allow users to select this option. Progress tracking in batch processing now uses video durations instead of file sizes for more accurate reporting. Adds a helper function to determine media duration using ffprobe.