### PR TITLE
Progress frame fixes

### DIFF
--- a/src/ui/progress_frame.py
+++ b/src/ui/progress_frame.py
@@ -11,7 +11,9 @@ class ProgressFrame(ttk.Frame):
         self.controller = controller
 
         self._start_perf = time.perf_counter()
-        self._last_eta_update_done = -1
+
+        # ETA learning state
+        self._last_eta_learn_done = -1  # ONLY advances on did_work=True
         self._last_cp_work = 0
         self._last_cp_elapsed = 0.0
         self._wps_ewma: float | None = None
@@ -23,27 +25,47 @@ class ProgressFrame(ttk.Frame):
         self.eta_var = tk.StringVar(value="ETA: estimating…")
         self.duration_var = tk.StringVar(value="Duration: 0:00 done / 0:00 left (of 0:00)")
 
-        ttk.Label(self, text="Progress", font=("Segoe UI", 16, "bold")).pack(anchor="w", pady=(10, 10))
+        # ---- GRID LAYOUT ----
+        self.columnconfigure(0, weight=1)
 
-        ttk.Label(self, textvariable=self.status_var, font=("Segoe UI", 12, "bold")).pack(anchor="w")
-        ttk.Label(self, textvariable=self.detail_var).pack(anchor="w", pady=(2, 8))
-        ttk.Label(self, textvariable=self.count_var).pack(anchor="w")
+        title = ttk.Label(self, text="Progress", font=("Segoe UI", 16, "bold"))
+        title.grid(row=0, column=0, sticky="w", padx=12, pady=(12, 10))
 
-        ttk.Label(self, textvariable=self.elapsed_var).pack(anchor="w", pady=(10, 0))
-        ttk.Label(self, textvariable=self.eta_var).pack(anchor="w", pady=(2, 0))
-        ttk.Label(self, textvariable=self.duration_var).pack(anchor="w", pady=(2, 0))
+        ttk.Label(self, textvariable=self.status_var, font=("Segoe UI", 12, "bold")).grid(
+            row=1, column=0, sticky="w", padx=12
+        )
+
+        detail_lbl = ttk.Label(self, textvariable=self.detail_var, wraplength=680, justify="left")
+        detail_lbl.grid(row=2, column=0, sticky="w", padx=12, pady=(2, 8))
+
+        ttk.Label(self, textvariable=self.count_var).grid(row=3, column=0, sticky="w", padx=12)
+        ttk.Label(self, textvariable=self.elapsed_var).grid(row=4, column=0, sticky="w", padx=12, pady=(10, 0))
+        ttk.Label(self, textvariable=self.eta_var).grid(row=5, column=0, sticky="w", padx=12, pady=(2, 0))
+        ttk.Label(self, textvariable=self.duration_var).grid(row=6, column=0, sticky="w", padx=12, pady=(2, 10))
 
         self.progress = ttk.Progressbar(self, mode="determinate")
-        self.progress.pack(fill="x", pady=(10, 10))
+        self.progress.grid(row=7, column=0, sticky="ew", padx=12, pady=(0, 10))
 
         btns = ttk.Frame(self)
-        btns.pack(fill="x")
-        ttk.Button(btns, text="Cancel", command=self.controller.cancel_work).pack(side="left")
-        ttk.Button(btns, text="Back to Setup", command=lambda: controller.show_frame("SetupFrame")).pack(side="right")
+        btns.grid(row=8, column=0, sticky="ew", padx=12, pady=(0, 12))
+        btns.columnconfigure(0, weight=1)
+        btns.columnconfigure(1, weight=1)
+
+        ttk.Button(btns, text="Cancel", command=self.controller.cancel_work).grid(row=0, column=0, sticky="w")
+        ttk.Button(btns, text="Back to Setup", command=lambda: controller.show_frame("SetupFrame")).grid(
+            row=0, column=1, sticky="e"
+        )
+
+        def _on_resize(_evt):
+            w = max(300, self.winfo_width() - 40)
+            detail_lbl.configure(wraplength=w)
+
+        self.bind("<Configure>", _on_resize)
 
     def reset(self):
         self._start_perf = time.perf_counter()
-        self._last_eta_update_done = -1
+
+        self._last_eta_learn_done = -1
         self._last_cp_work = 0
         self._last_cp_elapsed = 0.0
         self._wps_ewma = None
@@ -71,7 +93,6 @@ class ProgressFrame(ttk.Frame):
         self.count_var.set(f"Files: {done}/{total}")
         self.elapsed_var.set(f"Elapsed: {self.fmt_hms(int(elapsed_s))}")
 
-        # duration line always updates
         if total_work > 0:
             remaining = max(0, total_work - done_work)
             self.duration_var.set(
@@ -80,19 +101,26 @@ class ProgressFrame(ttk.Frame):
         else:
             self.duration_var.set(f"Duration: {self.fmt_hms(done_work)} done")
 
-        # Only update ETA on real work completions (avoids resume skip poisoning)
-        if done == self._last_eta_update_done:
-            return
-        self._last_eta_update_done = done
-
-        if done <= 0 or total_work <= 0 or not did_work:
+        # ---- ETA LEARNING FIX ----
+        # Only "learn" (and advance checkpoint) on did_work=True events.
+        # This prevents the earlier did_work=False progress event from locking ETA into "waiting".
+        if not did_work:
+            # Show a helpful message, but don't block learning later.
             if done <= 0:
                 self.eta_var.set("ETA: estimating…")
             else:
                 self.eta_var.set("ETA: waiting for real processing…")
             return
 
-        # Throughput based on work completed since last checkpoint
+        # Avoid learning twice for same completed count
+        if done == self._last_eta_learn_done:
+            return
+        self._last_eta_learn_done = done
+
+        if done_work <= 0 or total_work <= 0:
+            self.eta_var.set("ETA: estimating…")
+            return
+
         delta_work = done_work - self._last_cp_work
         delta_t = elapsed_s - self._last_cp_elapsed
 


### PR DESCRIPTION
This pull request introduces several improvements to the user interface and ETA calculation logic, focusing on clearer progress feedback, more accurate ETA learning, and enhanced responsiveness during batch operations. The most important changes are grouped below by theme.

**ETA Calculation and Progress Feedback Enhancements:**

* Refined the `_did_work_from_result` function in `src/core.py` to more accurately determine what constitutes "real work" for ETA learning. Explicit skips and "no speech" events no longer contribute to ETA training, while fallback logic ensures ETA is updated for non-trivial elapsed times.
* Updated the ETA learning logic in `ProgressFrame` (`src/ui/progress_frame.py`) to only update ETA estimates when actual work is detected, preventing skipped or pre-file events from skewing ETA calculations. The ETA display now distinguishes between "estimating" and "waiting for real processing" states. [[1]](diffhunk://#diff-a89c5a8fe9b1f05f40a9e9ee01a311179dd2aeee449424d5d24782120d0e4683L14-R16) [[2]](diffhunk://#diff-a89c5a8fe9b1f05f40a9e9ee01a311179dd2aeee449424d5d24782120d0e4683L83-L95)

**UI Layout and Responsiveness Improvements:**

* Migrated the `ProgressFrame` layout from `pack` to `grid`, improving alignment and responsiveness. Added dynamic wrapping for detail text and ensured UI elements resize appropriately.
* Added a busy indicator (spinner and label) to `SetupFrame` (`src/ui/setup_frame.py`) that activates during lengthy operations, such as scanning folders or starting work, providing immediate user feedback and disabling the start button to prevent duplicate actions. [[1]](diffhunk://#diff-2361810feeafe790ad2767fdc9f7f478dd6239b125aa7f88af3e1d94d9f070ddR20-R23) [[2]](diffhunk://#diff-2361810feeafe790ad2767fdc9f7f478dd6239b125aa7f88af3e1d94d9f070ddR49-R89)

**Batch Operation Handling:**

* Refactored the batch start logic in `SetupFrame` to show the busy indicator before scanning folders, improving perceived responsiveness. Introduced error handling and ensured UI unlocks if the user returns to the setup screen after an operation.